### PR TITLE
Fix JWT token generator timing issue with iat claim validation

### DIFF
--- a/standalone-mcp-server/scripts/generate_token.py
+++ b/standalone-mcp-server/scripts/generate_token.py
@@ -34,7 +34,7 @@ def generate_token(
     Returns:
         JWT token string
     """
-    now = datetime.utcnow()
+    now = datetime.utcnow() - timedelta(seconds=5)
     payload = {
         "sub": user_id,
         "name": name,
@@ -60,7 +60,12 @@ def decode_token(token: str, secret: str, algorithm: str = "HS256") -> Dict[str,
         Decoded payload
     """
     try:
-        payload = jwt.decode(token, secret, algorithms=[algorithm])
+        payload = jwt.decode(
+            token, 
+            secret, 
+            algorithms=[algorithm],
+            leeway=timedelta(seconds=10)  # Allow 10 seconds leeway for timing issues
+        )
         return payload
     except jwt.InvalidTokenError as e:
         raise ValueError(f"Invalid token: {str(e)}")


### PR DESCRIPTION
- Add 10-second leeway to jwt.decode() to handle clock skew and timing issues
- Set iat timestamp 5 seconds in the past to avoid ImmatureSignatureError
- Resolves 'The token is not yet valid (iat)' error when generating and immediately validating tokens
- Tested with user's exact command format and confirms successful token generation/validation